### PR TITLE
Python 3 and Fedora 31 compatibility

### DIFF
--- a/centos/__init__.py
+++ b/centos/__init__.py
@@ -1,8 +1,10 @@
-import defaults
+from __future__ import absolute_import
+
+from . import defaults
 
 __version__ = '0.1.0'
 
 
-from centos_cert import CentOSUserCert
-from centos.client import AccountSystem
+from .centos_cert import CentOSUserCert
+from .client import AccountSystem
 __all__ = ('CentOSUserCert','defaults', 'AccountSystem')

--- a/centos/centos_cert.py
+++ b/centos/centos_cert.py
@@ -1,8 +1,15 @@
 import os
 import requests
+import sys
 
 from OpenSSL import crypto
 from centos import defaults
+
+
+# Treat Py2 long as Py3 int
+if sys.version_info[:2] >= (3, 0):
+    long = int
+
 
 class CentOSUserCert(object):
 
@@ -21,7 +28,7 @@ class CentOSUserCert(object):
             # are all pieces of data we want to reference in this class
             self.__dict__.update(dict(self._cert.get_subject().get_components()))
 
-            self.expired = self._cert.has_expired() != 0L
+            self.expired = self._cert.has_expired() != long(0)
             self.serial = self._cert.get_serial_number()
 
     @property

--- a/python-centos.spec
+++ b/python-centos.spec
@@ -1,47 +1,154 @@
+%global srcname     centos
+%global common_description %{expand:
+Provides python bindings for the infrastructure services in the CentOS project.}
+
+# Enable/disable building against specific Pythons
+%if 0%{?fedora} >= 28 || 0%{?rhel} >= 8
+# On Fedora and newer EL: build only Python3 by default
+%bcond_with         python2
+%bcond_without      python3
+# In this setup, there are automatic dependency generators available
+%global             has_dependency_generators   1
+%else
+# On older Fedora and EL: build both Python 2 and 3 by default
+%bcond_without      python2
+%bcond_without      python3
+# In this setup, automatic dependency generators are not available
+%global             has_dependency_generators   0
+%endif
+
+# Specifically on EPEL, enable building against another Python 3
+%{?epel:%bcond_without python3_other}
+
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
-Name:		python-centos
-Version:	0.1.1
-Release:	2%{?dist}
-Summary:	Python bindings for the CentOS account system, CBS and other services
+Name:       python-%{srcname}
+Version:    0.1.1
+Release:    3%{?dist}
+Summary:    Python bindings for the CentOS account system, CBS and other services
 
-Group:		Applications/System
-License:	GPLv2
-URL:		https://centos.org/
-Source0:	python-centos-%{version}.tar.gz
+Group:      Applications/System
+License:    GPLv2
+URL:        https://centos.org/
+Source0:    python-centos-%{version}.tar.gz
 
-BuildRequires:	python-devel, python-setuptools
-Requires:   pyOpenSSL
-Requires:   python-munch
-Requires:   python-requests
-Requires:   python-urllib3
-Requires:   python-lockfile
-Requires:   python-kitchen
+BuildArch:  noarch
 
-BuildArch: noarch
+%description %{common_description}
 
-%description
-Provides python bindings for the infrastructure services in the CentOS project
+%if %{has_dependency_generators}
+%{?python_enable_dependency_generator}
+%endif
+
+%if %{with python2}
+%global py2_pkgname     %{expand:python2-%{srcname}}
+
+%package -n %{py2_pkgname}
+Summary:    %{summary}
+%{?python_provide:%python_provide %{py2_pkgname}}
+BuildRequires:  python2-devel
+BuildRequires:  python2-setuptools
+
+%if !%{has_dependency_generators}
+# On older releases, unversioned python is Python 2
+Requires:       pyOpenSSL
+Requires:       python-kitchen
+Requires:       python-lockfile
+Requires:       python-munch
+Requires:       python-requests
+Requires:       python-urllib3
+%endif
+
+%description -n %{py2_pkgname} %{common_description}
+%endif
+
+%if %{with python3}
+%global py3_pkgname     %{expand:python%{python3_pkgversion}-%{srcname}}
+
+%package -n %{py3_pkgname}
+Summary:    %{summary}
+%{?python_provide:%python_provide %{py3_pkgname}}
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-setuptools
+
+%if !%{has_dependency_generators}
+Requires:       python%{python3_pkgversion}-pyOpenSSL
+Requires:       python%{python3_pkgversion}-kitchen
+Requires:       python%{python3_pkgversion}-lockfile
+Requires:       python%{python3_pkgversion}-munch
+Requires:       python%{python3_pkgversion}-requests
+Requires:       python%{python3_pkgversion}-urllib3
+%endif
+
+%description -n %{py3_pkgname} %{common_description}
+%endif
+
+%if %{with python3_other}
+%global py3_other_pkgname %{expand:python%{python3_other_pkgversion}-%{srcname}}
+
+%package -n %{py3_other_pkgname}
+Summary:    %{summary}
+%{?python_provide:%python_provide %{py3_other_pkgname}}
+BuildRequires:  python%{python3_other_pkgversion}-devel
+BuildRequires:  python%{python3_other_pkgversion}-setuptools
+
+%if !%{has_dependency_generators}
+Requires:       python%{python3_other_pkgversion}-pyOpenSSL
+Requires:       python%{python3_other_pkgversion}-kitchen
+Requires:       python%{python3_other_pkgversion}-lockfile
+Requires:       python%{python3_other_pkgversion}-munch
+Requires:       python%{python3_other_pkgversion}-requests
+Requires:       python%{python3_other_pkgversion}-urllib3
+%endif
+
+%description -n %{py3_other_pkgname} %{common_description}
+%endif
 
 %prep
 %setup -q -c -n %{name}-%{version}
 
 %build
-%{__python} setup.py build
+%{?with_python2:%py2_build}
+%{?with_python3_other:%py3_other_build}
+%{?with_python3:%py3_build}
 
 %install
-%{__python} setup.py install -O1 --skip-build --root %{buildroot}
+%{?with_python2:%py2_install}
+%{?with_python3_other:%py3_other_install}
+%{?with_python3:%py3_install}
 
 %clean
 rm -rf %{buildroot}
 
-
-%files
+%if %{with python2}
+%files -n %{py2_pkgname}
 %defattr(-,root,root,-)
-%doc COPYING
-%{python_sitelib}/*
+%license COPYING
+%{python2_sitelib}/%{srcname}/
+%{python2_sitelib}/%{srcname}*.egg-info/
+%endif
+
+%if %{with python3}
+%files -n %{py3_pkgname}
+%defattr(-,root,root,-)
+%license COPYING
+%{python3_sitelib}/%{srcname}/
+%{python3_sitelib}/%{srcname}*.egg-info/
+%endif
+
+%if %{with python3_other}
+%files -n %{py3_other_pkgname}
+%defattr(-,root,root,-)
+%license COPYING
+%{python3_other_sitelib}/%{srcname}/
+%{python3_other_sitelib}/%{srcname}*.egg-info/
+%endif
 
 %changelog
+* Wed Nov 27 2019 Jan Staněk <jstanek@redhat.com> - 0.1.1-3
+- Make the code compatible with Python 3
+- Modernize spec file
+
 * Wed Jul 19 2017 brian@bstinson.com 0.1.1-2
 - Bumpspec to rebuild for F26
 
@@ -58,7 +165,7 @@ rm -rf %{buildroot}
 - Add the AccountSystem and a BR for python-fedora
 
 * Tue Aug 11 2015 brian@bstinson.com 0.0.2-1
-- Updated to dev version of library defaults 
+- Updated to dev version of library defaults
 
 * Sun Jul 26 2015 brian@bstinson.com 0.0.1-1
 - First build

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python
 
 from setuptools import find_packages, setup
 
@@ -10,4 +10,12 @@ setup(
     packages=find_packages(),
     license='GPLv2',
     version='0.1.1',
+    install_requires=[
+        "kitchen",
+        "lockfile",
+        "munch",
+        "pyOpenSSL",
+        "requests",
+        "urllib3",
+    ],
 )


### PR DESCRIPTION
This is an attempt to make the code and the SPEC file compatible with Python 3 and current Fedora package guidelines, respectively.

## Python compatibility

The code is now importable and usable in both Python 2 and Python 3, assuming all dependencies are available. Tested on CentOS 7 with EPEL for Python 2 and on Fedora 31 with Python 3.

## Spec file modernization

The spec file now produces multiple `noarch` RPMs, one for each relevant Python version available on the build platform. Production of these subpackages can be controlled with `--with pythonX` rpmbuild flags. Default configuration depends on the build platform, and are declared at the top of the spec file.

Also, if available, the package dependencies are pulled automatically from `setup.py`.

## Testing COPR

A package with these changes included is available in [jstanek/centos-packager](https://copr.fedorainfracloud.org/coprs/jstanek/centos-packager/) COPR.